### PR TITLE
updated python to generic 3.9, for github actions

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -11,10 +11,10 @@ jobs:
         - uses: actions/checkout@v2
           with:
             submodules: 'recursive'
-        - name: Set up Python 3.9.7
+        - name: Set up Python 3.9
           uses: actions/setup-python@v2
           with: 
-            python-version: '3.9.7'
+            python-version: '3.9'
         - name: Install dependencies
           run: |
             python -m pip install --upgrade pip


### PR DESCRIPTION
updated python to generic 3.9, for github actions
in the past there were issues with pyInstaller and py > 3.9.7